### PR TITLE
Make the fields on ListRepository public

### DIFF
--- a/src/output/list.rs
+++ b/src/output/list.rs
@@ -9,11 +9,11 @@ use crate::output::common::{Encryption, Repository};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ListRepository {
     /// Information about the repository
-    repository: Repository,
+    pub repository: Repository,
     /// Information about the encryption of the repository
-    encryption: Option<Encryption>,
+    pub encryption: Option<Encryption>,
     /// Information about the archives in the repository
-    archives: Vec<ListArchive>,
+    pub archives: Vec<ListArchive>,
 }
 
 /// The short output version of the archive


### PR DESCRIPTION
I wanted to use these fields in my project but I think they need to be public, so this PR adds that.

```rust
error[E0616]: field `archives` of struct `ListRepository` is private
   --> src/borg.rs:105:30
    |
105 |             for archive in l.archives {
    |                              ^^^^^^^^ private field

For more information about this error, try `rustc --explain E0616`.
error: could not compile `borgtui` due to previous error
```