### PR TITLE
Add support for mounting and unmounting archives and repositories

### DIFF
--- a/src/asynchronous/mod.rs
+++ b/src/asynchronous/mod.rs
@@ -7,12 +7,14 @@ pub use compact::compact;
 pub use create::{create, create_progress, CreateProgress};
 pub use init::init;
 pub use list::list;
+pub use mount::{mount, umount};
 pub use prune::prune;
 
 mod compact;
 mod create;
 mod init;
 mod list;
+mod mount;
 mod prune;
 
 pub(crate) async fn execute_borg(

--- a/src/asynchronous/mount.rs
+++ b/src/asynchronous/mount.rs
@@ -22,7 +22,7 @@ pub async fn mount(
 
     mount_parse_output(res)?;
 
-    info!("Finished pruning");
+    info!("Finished mounting");
 
     Ok(())
 }
@@ -40,7 +40,7 @@ pub async fn umount(mountpoint: String, common_options: &CommonOptions) -> Resul
 
     mount_parse_output(res)?;
 
-    info!("Finished pruning");
+    info!("Finished mounting");
 
     Ok(())
 }

--- a/src/asynchronous/mount.rs
+++ b/src/asynchronous/mount.rs
@@ -1,0 +1,46 @@
+use log::{debug, info};
+
+use crate::asynchronous::execute_borg;
+use crate::common::{mount_fmt_args, mount_parse_output, CommonOptions, MountOptions};
+use crate::errors::MountError;
+
+/// Mount an archive or repo as a FUSE filesystem.
+///
+/// **Parameter**:
+/// - `options`: Reference to [MountOptions]
+/// - `common_options`: The [CommonOptions] that can be applied to any command
+pub async fn mount(
+    options: &MountOptions,
+    common_options: &CommonOptions,
+) -> Result<(), MountError> {
+    let local_path = common_options.local_path.as_ref().map_or("borg", |x| x);
+
+    let args = mount_fmt_args(options, common_options);
+    debug!("Calling borg: {local_path} {args}");
+    let args = shlex::split(&args).ok_or(MountError::ShlexError)?;
+    let res = execute_borg(local_path, args, &options.passphrase).await?;
+
+    mount_parse_output(res)?;
+
+    info!("Finished pruning");
+
+    Ok(())
+}
+
+/// Unmount a previously mounted archive or repository.
+///
+/// **Parameter**:
+/// - `mountpoint`: The mountpoint to be unmounted.
+/// - `common_options`: The [CommonOptions] that can be applied to any command
+pub async fn umount(mountpoint: String, common_options: &CommonOptions) -> Result<(), MountError> {
+    let local_path = common_options.local_path.as_ref().map_or("borg", |x| x);
+
+    let args = vec!["umount".to_string(), mountpoint];
+    let res = execute_borg(local_path, args, &None).await?;
+
+    mount_parse_output(res)?;
+
+    info!("Finished pruning");
+
+    Ok(())
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -706,7 +706,7 @@ pub(crate) fn init_parse_result(res: Output) -> Result<(), InitError> {
 
         trace!("borg output: {line}");
 
-        let log_msg: LoggingMessage = serde_json::from_str(&line)?;
+        let log_msg = LoggingMessage::from_str(&line)?;
 
         if let LoggingMessage::LogMessage {
             name,
@@ -775,7 +775,7 @@ pub(crate) fn prune_parse_output(res: Output) -> Result<(), PruneError> {
 
         trace!("borg output: {line}");
 
-        let log_msg: LoggingMessage = serde_json::from_str(&line)?;
+        let log_msg = LoggingMessage::from_str(&line)?;
 
         if let LoggingMessage::LogMessage {
             name,
@@ -854,7 +854,11 @@ pub(crate) fn mount_parse_output(res: Output) -> Result<(), MountError> {
 
         trace!("borg output: {line}");
 
-        let log_msg: LoggingMessage = serde_json::from_str(&line)?;
+        let log_msg = LoggingMessage::from_str(&line)?;
+
+        if let LoggingMessage::UMountError(message) = log_msg {
+            return Err(MountError::UMountError(message));
+        };
 
         if let LoggingMessage::LogMessage {
             name,
@@ -901,7 +905,7 @@ pub(crate) fn list_parse_output(res: Output) -> Result<ListRepository, ListError
 
         trace!("borg output: {line}");
 
-        let log_msg: LoggingMessage = serde_json::from_str(&line)?;
+        let log_msg = LoggingMessage::from_str(&line)?;
 
         if let LoggingMessage::LogMessage {
             name,
@@ -997,7 +1001,7 @@ pub(crate) fn create_parse_output(res: Output) -> Result<Create, CreateError> {
 
         trace!("borg output: {line}");
 
-        let log_msg: LoggingMessage = serde_json::from_str(&line)?;
+        let log_msg = LoggingMessage::from_str(&line)?;
 
         if let LoggingMessage::LogMessage {
             name,
@@ -1058,7 +1062,7 @@ pub(crate) fn compact_parse_output(res: Output) -> Result<(), CompactError> {
 
         trace!("borg output: {line}");
 
-        let log_msg: LoggingMessage = serde_json::from_str(&line)?;
+        let log_msg = LoggingMessage::from_str(&line)?;
 
         if let LoggingMessage::LogMessage {
             name,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -132,6 +132,8 @@ pub enum MountError {
     /// Piping from stdout or stderr failed
     PipeFailed,
     /// An unexpected message id was received
+    UMountError(String),
+    /// An unexpected message id was received
     UnexpectedMessageId(MessageId),
 }
 
@@ -147,6 +149,7 @@ impl Display for MountError {
             }
             MountError::TerminatedBySignal => write!(f, "Borg was terminated by a signal"),
             MountError::PipeFailed => write!(f, "Piping from stdout or stderr failed"),
+            MountError::UMountError(message) => write!(f, "Failed to umount: {}", message),
             MountError::UnexpectedMessageId(x) => {
                 write!(f, "An unexpected message id was received: {x}")
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -114,6 +114,63 @@ impl From<serde_json::Error> for PruneError {
     }
 }
 
+/// The errors that can be returned from [crate::sync::mount]
+#[derive(Debug)]
+pub enum MountError {
+    /// An unknown error occurred
+    Unknown(String),
+    /// Error while splitting the arguments
+    ShlexError,
+    /// The command failed to execute
+    CommandFailed(io::Error),
+    /// Invalid borg output found
+    InvalidBorgOutput(io::Error),
+    /// Error while deserializing output of borg
+    DeserializeError(serde_json::Error),
+    /// Borg was terminated by a signal
+    TerminatedBySignal,
+    /// Piping from stdout or stderr failed
+    PipeFailed,
+    /// The specified archive name already exists
+    ArchiveAlreadyExists,
+    /// An unexpected message id was received
+    UnexpectedMessageId(MessageId),
+}
+
+impl Display for MountError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MountError::Unknown(output) => write!(f, "Unknown error occurred: {output}"),
+            MountError::ShlexError => write!(f, "error while splitting the arguments"),
+            MountError::CommandFailed(err) => write!(f, "The command failed to execute: {err}"),
+            MountError::InvalidBorgOutput(err) => write!(f, "Could not read borg output: {err}"),
+            MountError::DeserializeError(err) => {
+                write!(f, "Error while deserializing borg output: {err}")
+            }
+            MountError::TerminatedBySignal => write!(f, "Borg was terminated by a signal"),
+            MountError::PipeFailed => write!(f, "Piping from stdout or stderr failed"),
+            MountError::ArchiveAlreadyExists => {
+                write!(f, "The specified archive name already exists")
+            }
+            MountError::UnexpectedMessageId(x) => {
+                write!(f, "An unexpected message id was received: {x}")
+            }
+        }
+    }
+}
+
+impl From<io::Error> for MountError {
+    fn from(value: io::Error) -> Self {
+        Self::CommandFailed(value)
+    }
+}
+
+impl From<serde_json::Error> for MountError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::DeserializeError(value)
+    }
+}
+
 /// The errors that can be returned from [crate::sync::list]
 #[derive(Debug)]
 pub enum ListError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -131,8 +131,6 @@ pub enum MountError {
     TerminatedBySignal,
     /// Piping from stdout or stderr failed
     PipeFailed,
-    /// The specified archive name already exists
-    ArchiveAlreadyExists,
     /// An unexpected message id was received
     UnexpectedMessageId(MessageId),
 }
@@ -149,9 +147,6 @@ impl Display for MountError {
             }
             MountError::TerminatedBySignal => write!(f, "Borg was terminated by a signal"),
             MountError::PipeFailed => write!(f, "Piping from stdout or stderr failed"),
-            MountError::ArchiveAlreadyExists => {
-                write!(f, "The specified archive name already exists")
-            }
             MountError::UnexpectedMessageId(x) => {
                 write!(f, "An unexpected message id was received: {x}")
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -129,8 +129,6 @@ pub enum MountError {
     DeserializeError(serde_json::Error),
     /// Borg was terminated by a signal
     TerminatedBySignal,
-    /// Piping from stdout or stderr failed
-    PipeFailed,
     /// An unexpected message id was received
     UMountError(String),
     /// An unexpected message id was received
@@ -148,7 +146,6 @@ impl Display for MountError {
                 write!(f, "Error while deserializing borg output: {err}")
             }
             MountError::TerminatedBySignal => write!(f, "Borg was terminated by a signal"),
-            MountError::PipeFailed => write!(f, "Piping from stdout or stderr failed"),
             MountError::UMountError(message) => write!(f, "Failed to umount: {}", message),
             MountError::UnexpectedMessageId(x) => {
                 write!(f, "An unexpected message id was received: {x}")

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -7,12 +7,14 @@ pub use compact::compact;
 pub use create::create;
 pub use init::init;
 pub use list::list;
+pub use mount::{mount, umount};
 pub use prune::prune;
 
 mod compact;
 mod create;
 mod init;
 mod list;
+mod mount;
 mod prune;
 
 pub(crate) fn execute_borg(

--- a/src/sync/mount.rs
+++ b/src/sync/mount.rs
@@ -19,7 +19,7 @@ pub fn mount(options: &MountOptions, common_options: &CommonOptions) -> Result<(
 
     mount_parse_output(res)?;
 
-    info!("Finished pruning");
+    info!("Finished mounting");
 
     Ok(())
 }
@@ -37,7 +37,7 @@ pub fn umount(mountpoint: String, common_options: &CommonOptions) -> Result<(), 
 
     mount_parse_output(res)?;
 
-    info!("Finished pruning");
+    info!("Finished mounting");
 
     Ok(())
 }

--- a/src/sync/mount.rs
+++ b/src/sync/mount.rs
@@ -1,0 +1,43 @@
+use log::{debug, info};
+
+use crate::common::{mount_fmt_args, mount_parse_output, CommonOptions, MountOptions};
+use crate::errors::MountError;
+use crate::sync::execute_borg;
+
+/// Mount an archive or repo as a FUSE filesystem.
+///
+/// **Parameter**:
+/// - `options`: Reference to [MountOptions]
+/// - `common_options`: The [CommonOptions] that can be applied to any command
+pub fn mount(options: &MountOptions, common_options: &CommonOptions) -> Result<(), MountError> {
+    let local_path = common_options.local_path.as_ref().map_or("borg", |x| x);
+
+    let args = mount_fmt_args(options, common_options);
+    debug!("Calling borg: {local_path} {args}");
+    let args = shlex::split(&args).ok_or(MountError::ShlexError)?;
+    let res = execute_borg(local_path, args, &options.passphrase)?;
+
+    mount_parse_output(res)?;
+
+    info!("Finished pruning");
+
+    Ok(())
+}
+
+/// Unmount a previously mounted archive or repository.
+///
+/// **Parameter**:
+/// - `mountpoint`: The mountpoint to be unmounted.
+/// - `common_options`: The [CommonOptions] that can be applied to any command
+pub fn umount(mountpoint: String, common_options: &CommonOptions) -> Result<(), MountError> {
+    let local_path = common_options.local_path.as_ref().map_or("borg", |x| x);
+
+    let args = vec!["umount".to_string(), mountpoint];
+    let res = execute_borg(local_path, args, &None)?;
+
+    mount_parse_output(res)?;
+
+    info!("Finished pruning");
+
+    Ok(())
+}


### PR DESCRIPTION
This commit adds the `mount` and `umount` commands and associated options. The implementation was very similar to how prune was implemented. I tested the changes by pointing borgtui to these changes:

```
$ cargo run -q -- -p real mount ssh://<my-repo>/./repo test-mount
$ ls -l test-mount
real-2023-04-23:16:25:20
real-2023-04-23:23:27:23
...
$ cargo run -q -- -p real umount test-mount
$ ls -l test-mount
$
```