### PR TITLE
Add space after rsh arg formatting

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -269,7 +269,7 @@ impl From<&CommonOptions> for String {
         let mut s = String::new();
 
         if let Some(rsh) = &value.rsh {
-            s = format!("{s} --rsh {}", shell_escape(rsh));
+            s = format!("{s} --rsh {} ", shell_escape(rsh));
         }
 
         if let Some(remote_path) = &value.remote_path {


### PR DESCRIPTION
This was causing borgbackup to emit args with "create" appended to the rsh string instead of being its own entry after being split by shlex:

```
    [..., "ssh -i /mykeycreate", "--json", ...]
to -->
    [..., "ssh -i /mykey", "create", "--json", ...]
```