### PR TITLE
feat: add borg extract function for archive extraction

### DIFF
--- a/src/asynchronous/extract.rs
+++ b/src/asynchronous/extract.rs
@@ -1,0 +1,52 @@
+use log::{debug, info};
+use std::env;
+
+use crate::asynchronous::execute_borg;
+use crate::common::{extract_fmt_args, extract_parse_output, CommonOptions, ExtractOptions};
+use crate::errors::ExtractError;
+
+/// Extract the contents of an archive.
+///
+/// This command extracts the contents of an archive to the specified destination.
+/// By default, the entire archive is extracted but you can use the strip_components
+/// option to remove leading path elements.
+///
+/// **Parameter**:
+/// - `options`: Reference to [ExtractOptions]
+/// - `common_options`: The [CommonOptions] that can be applied to any command
+pub async fn extract(
+    options: &ExtractOptions,
+    common_options: &CommonOptions,
+) -> Result<(), ExtractError> {
+    let local_path = common_options.local_path.as_ref().map_or("borg", |x| x);
+
+    // Change to the destination directory before executing borg extract
+    let original_dir = env::current_dir().map_err(|e| {
+        ExtractError::CommandFailed(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to get current directory: {}", e),
+        ))
+    })?;
+
+    env::set_current_dir(&options.destination).map_err(|e| {
+        ExtractError::CommandFailed(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to change to destination directory: {}", e),
+        ))
+    })?;
+
+    let args = extract_fmt_args(options, common_options);
+    debug!("Calling borg: {local_path} {args}");
+    let args = shlex::split(&args).ok_or(ExtractError::ShlexError)?;
+    let res = execute_borg(local_path, args, &options.passphrase).await;
+
+    // Restore original directory
+    let _ = env::set_current_dir(original_dir);
+
+    let res = res?;
+    extract_parse_output(res)?;
+
+    info!("Finished extracting archive");
+
+    Ok(())
+}

--- a/src/asynchronous/mod.rs
+++ b/src/asynchronous/mod.rs
@@ -5,6 +5,7 @@ use std::process::Output;
 
 pub use compact::compact;
 pub use create::{create, create_progress, CreateProgress};
+pub use extract::extract;
 pub use init::init;
 pub use list::list;
 pub use mount::{mount, umount};
@@ -12,6 +13,7 @@ pub use prune::prune;
 
 mod compact;
 mod create;
+mod extract;
 mod init;
 mod list;
 mod mount;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -96,6 +96,32 @@ pub enum MountError {
     UnexpectedMessageId(MessageId),
 }
 
+/// The errors that can be returned from [crate::sync::extract]
+#[derive(Debug, Error)]
+pub enum ExtractError {
+    /// An unknown error occurred
+    #[error("Unknown error occurred: {0}")]
+    Unknown(String),
+    /// Error while splitting the arguments
+    #[error("error while splitting the arguments")]
+    ShlexError,
+    /// The command failed to execute
+    #[error("The command failed to execute: {0}")]
+    CommandFailed(#[from] io::Error),
+    /// Invalid borg output found
+    #[error("Error while deserializing borg output: {0}")]
+    InvalidBorgOutput(io::Error),
+    /// Error while deserializing output of borg
+    #[error("Error while deserializing borg output: {0}")]
+    DeserializeError(#[from] serde_json::Error),
+    /// Borg was terminated by a signal
+    #[error("Borg was terminated by a signal")]
+    TerminatedBySignal,
+    /// An unexpected message id was received
+    #[error("An unexpected message id was received: {0}")]
+    UnexpectedMessageId(MessageId),
+}
+
 /// The errors that can be returned from [crate::sync::list]
 #[derive(Error, Debug)]
 pub enum ListError {

--- a/src/sync/extract.rs
+++ b/src/sync/extract.rs
@@ -1,0 +1,52 @@
+use log::{debug, info};
+use std::env;
+
+use crate::common::{extract_fmt_args, extract_parse_output, CommonOptions, ExtractOptions};
+use crate::errors::ExtractError;
+use crate::sync::execute_borg;
+
+/// Extract the contents of an archive.
+///
+/// This command extracts the contents of an archive to the specified destination.
+/// By default, the entire archive is extracted but you can use the strip_components
+/// option to remove leading path elements.
+///
+/// **Parameter**:
+/// - `options`: Reference to [ExtractOptions]
+/// - `common_options`: The [CommonOptions] that can be applied to any command
+pub fn extract(
+    options: &ExtractOptions,
+    common_options: &CommonOptions,
+) -> Result<(), ExtractError> {
+    let local_path = common_options.local_path.as_ref().map_or("borg", |x| x);
+
+    // Change to the destination directory before executing borg extract
+    let original_dir = env::current_dir().map_err(|e| {
+        ExtractError::CommandFailed(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to get current directory: {}", e),
+        ))
+    })?;
+
+    env::set_current_dir(&options.destination).map_err(|e| {
+        ExtractError::CommandFailed(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to change to destination directory: {}", e),
+        ))
+    })?;
+
+    let args = extract_fmt_args(options, common_options);
+    debug!("Calling borg: {local_path} {args}");
+    let args = shlex::split(&args).ok_or(ExtractError::ShlexError)?;
+    let res = execute_borg(local_path, args, &options.passphrase);
+
+    // Restore original directory
+    let _ = env::set_current_dir(original_dir);
+
+    let res = res?;
+    extract_parse_output(res)?;
+
+    info!("Finished extracting archive");
+
+    Ok(())
+}

--- a/src/sync/extract.rs
+++ b/src/sync/extract.rs
@@ -28,6 +28,29 @@ pub fn extract(
         ))
     })?;
 
+    // Execute extraction, capturing result before cleanup
+    let result = extract_in_destination(local_path, options, common_options);
+
+    // Always restore original directory
+    env::set_current_dir(original_dir).map_err(|e| {
+        ExtractError::CommandFailed(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to restore original directory: {}", e),
+        ))
+    })?;
+
+    result?;
+
+    info!("Finished extracting archive");
+
+    Ok(())
+}
+
+fn extract_in_destination(
+    local_path: &str,
+    options: &ExtractOptions,
+    common_options: &CommonOptions,
+) -> Result<(), ExtractError> {
     env::set_current_dir(&options.destination).map_err(|e| {
         ExtractError::CommandFailed(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -38,15 +61,8 @@ pub fn extract(
     let args = extract_fmt_args(options, common_options);
     debug!("Calling borg: {local_path} {args}");
     let args = shlex::split(&args).ok_or(ExtractError::ShlexError)?;
-    let res = execute_borg(local_path, args, &options.passphrase);
-
-    // Restore original directory
-    let _ = env::set_current_dir(original_dir);
-
-    let res = res?;
+    let res = execute_borg(local_path, args, &options.passphrase)?;
     extract_parse_output(res)?;
-
-    info!("Finished extracting archive");
 
     Ok(())
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Output};
 
 pub use compact::compact;
 pub use create::create;
+pub use extract::extract;
 pub use init::init;
 pub use list::list;
 pub use mount::{mount, umount};
@@ -12,6 +13,7 @@ pub use prune::prune;
 
 mod compact;
 mod create;
+mod extract;
 mod init;
 mod list;
 mod mount;


### PR DESCRIPTION
Hey thanks for making this crate!

I am using your crate on a project of mine and I needed the extract feature. I figured I would update your repository if you'd also like this feature. 🫡 

## Description

Implements synchronous and asynchronous extract functions to support
extracting archives from borg repositories.

## Changes:
- Add ExtractError enum to errors.rs for extract-specific error handling
- Add ExtractOptions struct to common.rs with repository, archive,
  destination, passphrase, and strip_components fields
- Implement extract_fmt_args() to format borg CLI arguments
- Implement extract_parse_output() to parse command output and errors
- Add sync::extract() function with directory change handling
- Add asynchronous::extract() function using tokio
- Export extract functions in both sync and asynchronous modules

The extract function supports:
- Repository and archive specification (repo::archive format)
- Custom extraction destination path
- --strip-components flag to remove leading path elements
- Passphrase support for encrypted repositories
- Proper error handling following MPL 2.0 licensed crate conventions

Follows the same implementation pattern as existing functions like
create() and list() for consistency with the codebase.