### PR TITLE
Add BackupPermissionError support

### DIFF
--- a/src/output/logging.rs
+++ b/src/output/logging.rs
@@ -151,6 +151,8 @@ pub enum MessageId {
     ArchiveIncompatibleFilesystemEncodingError,
     /// Obscure ENOENT error
     BackupFileNotFoundError,
+    /// Backup failed due to a permission error
+    BackupPermissionError,
     /// Cache initialization aborted
     #[serde(rename = "Cache.CacheInitAbortedError")]
     CacheCacheInitAbortedError,
@@ -299,6 +301,7 @@ impl Display for MessageId {
                 write!(f, "Archive.IncompatibleFilesystemEncodingError")
             }
             MessageId::BackupFileNotFoundError => write!(f, "BackupFileNotFoundError"),
+            MessageId::BackupPermissionError => write!(f, "BackupPermissionError"),
             MessageId::CacheCacheInitAbortedError => write!(f, "Cache.CacheInitAbortedError"),
             MessageId::CacheEncryptionMethodMismatch => write!(f, "Cache.EncryptionMethodMismatch"),
             MessageId::CacheRepositoryAccessAborted => write!(f, "Cache.RepositoryAccessAborted"),


### PR DESCRIPTION
For unknown reasons I started getting a permission denied error on my system. So I added an enum to make the error message a bit nicer.

```
ERROR borgtui: error_message="Failed to create archive default-2026-04-10:14:36:15 in repo /hdd2/Backup:
DeserializeError(Error(\"unknown variant `BackupPermissionError`, expected one of `Archive.AlreadyExists`, `Archive.DoesNotExist`,
`Archive.IncompatibleFilesystemEncodingError`, `BackupFileNotFoundError`, `Cache.CacheInitAbortedError`, `Cache.EncryptionMethodMismatch`,
`Cache.RepositoryAccessAborted`, `Cache.RepositoryIDNotUnique`, `Cache.RepositoryReplay`, `Buffer.MemoryLimitExceeded`, `ExtensionModuleError`, `IntegrityError`,
`NoManifestError`, `PlaceholderError`, `KeyfileInvalidError`, `KeyfileMismatchError`, `KeyfileNotFoundError`, `PassphraseWrong`, `PasswordRetriesExceeded`,
`RepoKeyNotFoundError`, `UnsupportedManifestError`, `UnsupportedPayloadError`, `NotABorgKeyFile`, `RepoIdMismatch`, `UnencryptedRepo`, `UnknownKeyType`, `LockError`,
`LockErrorT`, `ConnectionClosed`, `InvalidRPCMethod`, `PathNotAllowed`, `NoPassphraseFailure`, `RemoteRepository.RPCServerOutdated`,
`UnexpectedRPCDataFormatFromClient`, `UnexpectedRPCDataFormatFromServer`, `Repository.AlreadyExists`, `Repository.CheckNeeded`, `Repository.DoesNotExist`,
`Repository.InsufficientFreeSpaceError`, `Repository.InvalidRepository`, `Repository.AtticRepository`, `Repository.ObjectNotFound`, `cache.begin_transaction`,
`cache.download_chunks`, `cache.commit`, `cache.sync`, `repository.compact_segments`, `repository.replay_segments`, `repository.check`, `check.verify_data`,
`check.rebuild_manifest`, `extract`, `extract.permissions`, `archive.delete`, `archive.calc_stats`, `prune`, `upgrade.convert_segments`\", line: 0, column: 0))"
```